### PR TITLE
RR: Correct hyphen in 'open-source'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # GT OSPO Summer Internship Program
 
-In collaboration with researchers from IBM, the GT OSPO is establishing a new Virtual Summer Internship Program for students to participate in various open-source projects during the 2024 summer session. During the internship, students will join an open source project, work with the developers and maintainers of that project to make contributions to the code base, and learn useful software development and engineering skills to engage with the wider open source community. 
+In collaboration with researchers from IBM, the GT OSPO is establishing a new Virtual Summer Internship Program for students to participate in various open-source projects during the 2024 summer session. During the internship, students will join an open source project, work with the developers and maintainers of that project to make contributions to the code base, and learn useful software development and engineering skills to engage with the wider open-source community. 
 
 If you are interested to learn more about this internship, please see the [main VSIP program page here](https://ospo.cc.gatech.edu/vsip/) and the [agenda for the February 27th event](https://github.com/gt-ospo/summer-internship-program/blob/main/2024/information_session_agenda.md). 


### PR DESCRIPTION
# Description

(The purpose of this PR was to demonstrate a PR for training module 02)

We had some inconsistent hyphenation for "open source" vs "open-source".  My research has shown few projects can agree on this, but I am choosing "open-source".