### PR TITLE
Update granite-tutorial-supplemental.md

### DIFF
--- a/2025/granite-tutorial-supplemental.md
+++ b/2025/granite-tutorial-supplemental.md
@@ -34,7 +34,7 @@ A new terminal window should open, you can now run the following commands to set
 
 - Step 2. Declare the virtual environment
 ```
-[login-ice ~]$ python -m venv --upgrade-deps --clear venv granite_env
+[login-ice ~]$ python -m venv --upgrade-deps --clear granite_env
 ```
 > [!NOTE]
 > We've named our venv "granite_venv" here but you can name it whatever you like - just adjust accordingly!


### PR DESCRIPTION
In the Granite tutorial supplemental docs, we have a typo in the command used to create the virtual environment.  This PR fixes the command.  