### PR TITLE
Update granite-tutorial-supplemental.md

### DIFF
--- a/2025/granite-tutorial-supplemental.md
+++ b/2025/granite-tutorial-supplemental.md
@@ -118,6 +118,7 @@ except Exception: # Use Replicate for the model
 ```Python
 import os
 from langchain_ollama.llms import OllamaLLM
+from ibm_granite_community.notebook_utils import get_env_var
 
 model_path = "ibm-granite/granite-3.3-8b-instruct"
 model = OllamaLLM(


### PR DESCRIPTION
In the Granite tutorial supplemental docs, we described changing a notebook cell to start the Ollama session.  However, in the docs, I forgot to keep a module import necessary for the remainder for the notebook.  This PR corrects that.  

