### PR TITLE
README: Omit hyphen from "open-source"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GT OSPO Summer Internship Program
 
-Starting in 2024, the GT Open Source Program Office (OSPO) has run a new Virtual Summer Internship Program for students to participate in various open-source projects during the summer session. During this virtual internship, students joined an open source project, worked with the developers and maintainers of that project to make contributions to the code base, and learned useful software development and engineering skills to engage with the wider open-source community. 
+Starting in 2024, the GT Open Source Program Office (OSPO) has run a new Virtual Summer Internship Program for students to participate in various open source projects during the summer session. During this virtual internship, students joined an open source project, worked with the developers and maintainers of that project to make contributions to the code base, and learned useful software development and engineering skills to engage with the wider open source community. 
 
 > [!NOTE]
 > This page provides links to public presentations and resources related to this program. Please see our main landing page [here](https://ospo.cc.gatech.edu/vsip/) for any applications or links to forms.


### PR DESCRIPTION
Fixes #12 

There were two instances of "open-source" in README that I fixed