### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## How To Report a Vulnerability
+
+If you think you have found a vulnerability in this repository, please report it to us through coordinated disclosure.
+
+**Please do not report security vulnerabilities through public issues, discussions, or change requests.**
+
+Instead, report it using one of the following ways:
+
+* https://github.com/gt-ospo/summer-internship-program/security/advisories/new - Report directly via private vulnerability reporting on GitHub
+<!-- Alternatively, add another contact method for reporting vulnerabilities, e.g. a security email address -->
+
+Please include as much of the information listed below as you can to help us better understand and resolve the issue:
+
+* The type of issue (e.g., buffer overflow, SQL injection, or cross-site scripting)
+* Affected version(s)
+* Impact of the issue, including how an attacker might exploit the issue
+* Step-by-step instructions to reproduce the issue
+* The location of the affected source code (tag/branch/commit or direct URL)
+* Full paths of source file(s) related to the manifestation of the issue
+* Configuration required to reproduce the issue
+* Log files that are related to this issue (if possible)
+* Proof-of-concept or exploit code (if possible)
+
+## Supported Versions:


### PR DESCRIPTION
**What is `SECURITY.md`?** It's the file GitHub uses to tell people how to report a security vulnerability in a project. When it's present, GitHub shows a "Report a vulnerability" link on the repository so researchers know where to send issues privately instead of opening a public one. This repository doesn't have this file yet, so this PR adds it.

The added `SECURITY.md` highlights the recommended best practice for reporting: **GitHub's private vulnerability reporting**, a built-in, private channel between researchers and maintainers. **If you haven't already, please turn it on** under the repository's **Settings → Code security**, then enable [Private vulnerability reporting](https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/configure-for-a-repository).

**Prefer to receive reports a different way?** Just edit `SECURITY.md` to point to your preferred contact instead — for example, a dedicated security email address.
